### PR TITLE
Event.h, FunctionPointer.h, and mbed-sbrk are moving to mbed-util

### DIFF
--- a/minar/minar.h
+++ b/minar/minar.h
@@ -43,7 +43,7 @@ enum Constants{
 };
 
 /// Basic callback type
-typedef mbed::Event callback_t;
+typedef mbed::util::Event callback_t;
 
 /// Internal time type
 typedef platform::tick_t tick_t;
@@ -103,7 +103,7 @@ class Scheduler{
 
 
         // Function for posting callbacks using FunctionPointer objects without arguments
-        static CallbackAdder postCallback(mbed::FunctionPointer& callback)
+        static CallbackAdder postCallback(mbed::util::FunctionPointer& callback)
         {
             return postCallback(callback.bind());
         }
@@ -112,13 +112,13 @@ class Scheduler{
         // and objects/member pointers without arguments
         static CallbackAdder postCallback(void (*callback)(void))
         {
-            return postCallback(mbed::FunctionPointer(callback).bind());
+            return postCallback(mbed::util::FunctionPointer(callback).bind());
         }
 
         template<typename T>
         static CallbackAdder postCallback(T *object, void (T::*member)())
         {
-            return postCallback(mbed::FunctionPointer(object, member).bind());
+            return postCallback(mbed::util::FunctionPointer(object, member).bind());
         }
 
         static int cancelCallback(callback_handle_t handle);

--- a/minar/minar.h
+++ b/minar/minar.h
@@ -22,8 +22,8 @@
 #include "minar-platform/minar_platform.h"
 //#include "mbed.h"
 // [TODO] change this
-#include "mbed/Event.h"
-#include "FunctionPointer.h"
+#include "mbed-util/Event.h"
+#include "mbed-util/FunctionPointer.h"
 
 namespace minar{
 

--- a/module.json
+++ b/module.json
@@ -21,8 +21,12 @@
   "dependencies": {
     "compiler-polyfill": "~1.0.3",
     "minar-platform": "~0.3.0",
-    "mbed-drivers": "~0.7.0",
     "core-util": "~0.0.6"
+  },
+  "targetDependencies": {
+    "mbed": {
+      "mbed-drivers": "~0.7.0"
+    }
   },
   "scripts": {
     "testReporter": [

--- a/module.json
+++ b/module.json
@@ -23,11 +23,6 @@
     "minar-platform": "~0.3.0",
     "core-util": "~0.0.6"
   },
-  "targetDependencies": {
-    "mbed": {
-      "mbed-drivers": "~0.7.0"
-    }
-  },
   "scripts": {
     "testReporter": [
       "mbedgt",

--- a/source/minar.cpp
+++ b/source/minar.cpp
@@ -16,7 +16,9 @@
  */
 
 #include "minar/minar.h"
+#ifndef YOTTA_CFG_POSIX
 #include "mbed.h"
+#endif /* #ifndef YOTTA_CFG_POSIX */
 
 #include <stdlib.h>
 #include <limits.h>

--- a/source/minar.cpp
+++ b/source/minar.cpp
@@ -16,9 +16,6 @@
  */
 
 #include "minar/minar.h"
-#ifndef YOTTA_CFG_POSIX
-#include "mbed.h"
-#endif /* #ifndef YOTTA_CFG_POSIX */
 
 #include <stdlib.h>
 #include <limits.h>


### PR DESCRIPTION
refer to https://github.com/ARMmbed/core-util/pull/21 and https://github.com/ARMmbed/mbed-drivers/pull/85

@bogdanm @autopulated 
