### PR TITLE
Module - update core and minar platform dep

### DIFF
--- a/module.json
+++ b/module.json
@@ -19,9 +19,9 @@
     }
   ],
   "dependencies": {
-    "compiler-polyfill": "~1.0.3",
-    "minar-platform": "~0.3.0",
-    "core-util": "~0.2.0"
+    "compiler-polyfill": "~1.1.0",
+    "minar-platform": "~0.4.0",
+    "core-util": "~0.3.0"
   },
   "scripts": {
     "testReporter": [


### PR DESCRIPTION
This depends on the https://github.com/ARMmbed/minar-platform/pull/3. Once it gets merged and a new version is published, the minar-platform dep should use that version in this repository.

Tested locally with disco429 and frdm-k64f (many repositories locally linked, ongoing updates)

@bogdanm 