### PR TITLE
Fix dropped periodic callbacks

### DIFF
--- a/source/minar.cpp
+++ b/source/minar.cpp
@@ -387,6 +387,10 @@ int minar::SchedulerData::start(){
                 //
                 // We have to perform this update with interrupts disabled
                 // because we use last_dispatch for sorting dispatch_tree
+                //
+                // next is guaranteed to be the next item in must-execute-by
+                // order, since the callback list is sorted in must-execute-by
+                // order.
                 last_dispatch = smallestTimeIncrement(last_dispatch, now, next->call_before);
 
                 const minar::tick_t lag = wrapTime(now - last_dispatch);

--- a/source/minar.cpp
+++ b/source/minar.cpp
@@ -387,10 +387,7 @@ int minar::SchedulerData::start(){
                 //
                 // We have to perform this update with interrupts disabled
                 // because we use last_dispatch for sorting dispatch_tree
-                if(dispatch_tree.get_num_elements() > 0)
-                    last_dispatch = smallestTimeIncrement(last_dispatch, now, (dispatch_tree.get_root())->call_before);
-                else
-                    last_dispatch = smallestTimeIncrement(last_dispatch, now, next->call_before);
+                last_dispatch = smallestTimeIncrement(last_dispatch, now, next->call_before);
 
                 const minar::tick_t lag = wrapTime(now - last_dispatch);
                 if(lag > Warn_Lag_Ticks)


### PR DESCRIPTION
Under some circumstances, minar can schedule periodic callbacks in the past. Here are the conditions for failure:

* Minar is lagging beyond the interval of a periodic callback (CB1), when it is scheduled.
* Minar has at least one other callback in the queue (CB2)
* ```CB2->call_before``` is later than ```CB1->call_before``` + ```CB1->next_interval```

When executing here: https://github.com/ARMmbed/minar/blob/b4a40aa284a737dabe19b601e3817f2b01a56966/source/minar.cpp#L390, minar will execute the first half of the branch, setting last_dispatch later than ```CB1->call_before + CB1->next_interval```.  Then, when execution reaches https://github.com/ARMmbed/minar/blob/b4a40aa284a737dabe19b601e3817f2b01a56966/source/minar.cpp#L462, the next instance of CB1 will be scheduled in the past.

To correct this problem, ```last_dispatch``` must be advanced only as far as the current callback’s ```call_before```.  Since the heap is already sorted in order of earliest ```call_before```, it doesn’t make sense to inspect the following element’s ```call_before``` when setting ```last_dispatch```, as is currently done at https://github.com/ARMmbed/minar/blob/b4a40aa284a737dabe19b601e3817f2b01a56966/source/minar.cpp#L391

This fix removes any inspection of following elements.

Fixes #12