### PR TITLE
Fix a period callback error and a tolerance error

### DIFF
--- a/source/minar.cpp
+++ b/source/minar.cpp
@@ -251,7 +251,7 @@ int minar::SchedulerData::start(){
 
             if(dispatch_tree.get_num_elements() > 0) {
                 CallbackNode *root = dispatch_tree.get_root();
-                now_plus_tolerance = wrapTime(now + root->tolerance);
+                now_plus_tolerance = wrapTime(now + root->tolerance/2);
                 if (timeIsInPeriod(last_dispatch, root->call_before, now_plus_tolerance)) {
                     best = root;
                 }
@@ -378,7 +378,7 @@ minar::callback_handle_t minar::SchedulerData::postGeneric(
 
     CallbackNode* n = new CallbackNode(
         cb,
-        wrapTime(at + interval),
+        wrapTime(at),
         2 * double_sided_tolerance,
         interval
     );


### PR DESCRIPTION
1. The first callback of a period callback now happens
immediately after postcallback() instead of one period
interval later.

2. The tolerance is stored as double sided tolerance
but used as single sided, with effect of have double
the tolerance as user intended. This has been fixed.


Test result:

| target        | platform_name | test                                                    | result | elapsed_time (sec) | copy_method |
| ----        | ---- | ----                                                    | ---- | ---- | ---- |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar001_repeated_call_instance        | OK     | 2.32               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar003_simple_callback               | OK     | 2.28               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar004_simple_period_callback        | OK     | 2.3                | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar005_long_period_callback          | OK     | 3.2                | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar006_period_and_regular_callback   | OK     | 2.76               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar007_no_overlap_period_callback    | OK     | 2.64               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar008_overlapping_period_callback   | OK     | 2.49               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar009_mixed_callbacks               | OK     | 2.43               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar010_period_with_tolerence         | OK     | 2.49               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar011_tolerance_and_delays          | OK     | 2.75               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar012_three_period_callbacks        | OK     | 2.44               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar013_three_regular_one_period      | OK     | 2.4                | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar014_four_periodic_callbacks       | OK     | 2.52               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar015_three_regular_three_period    | OK     | 3.29               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar016_remove_and_reschedule         | OK     | 2.37               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar021_interrupt_safety              | OK     | 2.3                | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar023_period_less_than_tolerance    | OK     | 4.25               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar024_cancel_inexistent_callback    | OK     | 2.3                | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar025_cancel_callback_twice         | OK     | 2.25               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar027_call_start_while_running      | FAIL   | 2.35               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar028_call_stop_while_not_running   | OK     | 2.31               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar029_schedule_single_pool          | OK     | 2.32               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar030_schedule_single_pool_plus_one | OK     | 2.34               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar031_full_and_additional_pool      | OK     | 2.37               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar032_full_additional_pool_plus1    | OK     | 2.38               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar033_test_out_of_memory            | OK     | 1.96               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar034_1000_callbacks_memcheck       | OK     | 2.54               | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar035_one_thousand_callbacks        | OK     | 3.6                | shell       |
| frdm-k64f-gcc | K64F          | minar-tests-test-minar036_warn_duration_milliseconds    | FAIL   | 1.96               | shell       |

Note that minar036 and 027 are expected to fail
@bogdanm @0xc0170 Please review