### PR TITLE
[devel_transport] Port tests to new version of greentea

### DIFF
--- a/module.json
+++ b/module.json
@@ -24,7 +24,8 @@
     "core-util": "^1.0.0"
   },
   "testDependencies": {
-    "greentea-client": "~0.1.4"
+    "greentea-client": "~0.1.4",
+    "unity": "^2.0.0"
   },
   "scripts": {
     "testReporter": [

--- a/module.json
+++ b/module.json
@@ -23,6 +23,9 @@
     "minar-platform": "^1.0.0",
     "core-util": "^1.0.0"
   },
+  "testDependencies": {
+    "greentea-client": "~0.1.4"
+  },
   "scripts": {
     "testReporter": [
       "mbedgt",

--- a/test/complex_dispatch.cpp
+++ b/test/complex_dispatch.cpp
@@ -18,7 +18,7 @@
 #include <stdio.h>
 #include "minar/minar.h"
 #include "mbed-drivers/mbed.h"
-#include "mbed-drivers/test_env.h"
+#include "greentea-client/test_env.h"
 #include "core-util/FunctionPointer.h"
 
 using mbed::util::FunctionPointer0;
@@ -67,11 +67,8 @@ static void stop_scheduler() {
 }
 
 void app_start(int, char*[]) {
-    MBED_HOSTTEST_TIMEOUT(35);
-    MBED_HOSTTEST_SELECT(default);
-    MBED_HOSTTEST_DESCRIPTION(MINAR complex dispatch test);
-
-    MBED_HOSTTEST_START("MINAR_COMPLEX_DISPATCH");
+    GREENTEA_SETUP(35, "default");
+    
     LED led1("led1", LED1);
     LED led2("led2", LED2);
 
@@ -113,6 +110,6 @@ void app_start(int, char*[]) {
     if (cb_cnt != EXPECTED_CALLBACK_COUNT)
         printf("ERROR: final callback count is %d, should be %d\r\n", cb_cnt, EXPECTED_CALLBACK_COUNT);
 
-    MBED_HOSTTEST_RESULT(cnt_ok && (cb_cnt == 1));
+    GREENTEA_TESTSUITE_RESULT(cnt_ok && (cb_cnt == 1));
 }
 

--- a/test/complex_dispatch.cpp
+++ b/test/complex_dispatch.cpp
@@ -19,6 +19,7 @@
 #include "minar/minar.h"
 #include "mbed-drivers/mbed.h"
 #include "greentea-client/test_env.h"
+#include "unity/unity.h"
 #include "core-util/FunctionPointer.h"
 
 using mbed::util::FunctionPointer0;
@@ -105,11 +106,9 @@ void app_start(int, char*[]) {
 
     bool cnt_ok = (cnt >= MIN_ALLOWED_CNT) && (cnt <= MAX_ALLOWED_CNT);
     printf("Final counter value: %d\r\n", cnt);
-    if (!cnt_ok)
-        printf("ERROR: counter value is out of range (should be between %d and %d)\r\n", MIN_ALLOWED_CNT, MAX_ALLOWED_CNT);
-    if (cb_cnt != EXPECTED_CALLBACK_COUNT)
-        printf("ERROR: final callback count is %d, should be %d\r\n", cb_cnt, EXPECTED_CALLBACK_COUNT);
+    TEST_ASSERT_TRUE_MESSAGE(cnt_ok, "Counter value is out of range");
+    TEST_ASSERT_EQUAL_MESSAGE(EXPECTED_CALLBACK_COUNT, cb_cnt, "Wrong call back count!");
 
-    GREENTEA_TESTSUITE_RESULT(cnt_ok && (cb_cnt == 1));
+    GREENTEA_TESTSUITE_RESULT(cnt_ok && (cb_cnt == EXPECTED_CALLBACK_COUNT));
 }
 

--- a/test/dispatchtest.cpp
+++ b/test/dispatchtest.cpp
@@ -23,7 +23,7 @@
 #include "mbed-drivers/mbed.h"
 #include "minar/minar.h"
 #include "core-util/FunctionPointer.h"
-#include "mbed-drivers/test_env.h"
+#include "greentea-client/test_env.h"
 
 using mbed::util::FunctionPointer0;
 
@@ -42,16 +42,12 @@ static void toggleLED2()
 
 static void testComplete()
 {
-    MBED_HOSTTEST_RESULT(true);
+    GREENTEA_TESTSUITE_RESULT(true);
 }
 
 void app_start(int, char*[])
 {
-    MBED_HOSTTEST_TIMEOUT(20);
-    MBED_HOSTTEST_SELECT(default);
-    MBED_HOSTTEST_DESCRIPTION(Dispatch test);
-
-    MBED_HOSTTEST_START("DISPATCH_TEST");
+    GREENTEA_SETUP(20, "default");
 
     minar::Scheduler::postCallback(FunctionPointer0<void>(toggleLED1).bind())
         .period(minar::milliseconds(500))


### PR DESCRIPTION
Test results from ```$mbedgt -VS --report-junit JUnit.xml```:
```
mbedgt: test suite report:
+---------------+---------------+-----------------------------+--------+--------------------+-------------+
| target        | platform_name | test suite                  | result | elapsed_time (sec) | copy_method |
+---------------+---------------+-----------------------------+--------+--------------------+-------------+
| frdm-k64f-gcc | K64F          | minar-test-complex_dispatch | OK     | 39.77              | shell       |
| frdm-k64f-gcc | K64F          | minar-test-dispatchtest     | OK     | 24.93              | shell       |
+---------------+---------------+-----------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 2 OK
mbedgt: test case report:
+---------------+---------------+-----------------------------+------------------+--------+--------+--------+--------------------+
| target        | platform_name | test suite                  | test case        | passed | failed | result | elapsed_time (sec) |
+---------------+---------------+-----------------------------+------------------+--------+--------+--------+--------------------+
| frdm-k64f-gcc | K64F          | minar-test-complex_dispatch | complex_dispatch | 1      | 0      | OK     | 39.77              |
| frdm-k64f-gcc | K64F          | minar-test-dispatchtest     | dispatchtest     | 1      | 0      | OK     | 24.93              |
+---------------+---------------+-----------------------------+------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 2 OK
mbedgt: completed in 66.22 sec
```
```
$yt ls
minar 1.0.4
|_ compiler-polyfill 1.2.1
|_ minar-platform 1.0.0
| |_ minar-platform-mbed 1.1.2 yotta_modules\minar-platform-mbed
| | \_ mbed-hal 1.2.2 yotta_modules\mbed-hal
| |   |_ mbed-drivers 1.0.0 yotta_modules\mbed-drivers
| |   | \_ ualloc 1.0.3 yotta_modules\ualloc
| |   |   \_ dlmalloc 1.0.0 yotta_modules\dlmalloc
| |   \_ mbed-hal-freescale 1.0.0 yotta_modules\mbed-hal-freescale
| |     \_ mbed-hal-ksdk-mcu 1.0.8 yotta_modules\mbed-hal-ksdk-mcu
| |       |_ uvisor-lib 1.0.13 yotta_modules\uvisor-lib
| |       \_ mbed-hal-k64f 1.1.0 yotta_modules\mbed-hal-k64f
| |         \_ mbed-hal-frdm-k64f 1.0.2 yotta_modules\mbed-hal-frdm-k64f
| \_ cmsis-core 1.1.2 yotta_modules\cmsis-core
|   \_ cmsis-core-freescale 1.0.0 yotta_modules\cmsis-core-freescale
|     \_ cmsis-core-k64f 1.0.0 yotta_modules\cmsis-core-k64f
|_ core-util 1.5.1
\_ greentea-client 0.1.4 (test dependency)
```